### PR TITLE
Fixes Chrome field losing focus

### DIFF
--- a/js/bootstrap-suggest.js
+++ b/js/bootstrap-suggest.js
@@ -228,6 +228,7 @@
 				.on('click', function(e) {
 					e.preventDefault();
 					that.__select($(this).index());
+					that.$element.focus();
 				})
 				.on('mouseover', function(e) {
 					that.$element.off('blur', blur);


### PR DESCRIPTION
In the latest version of Chrome, the text field loses focus when mouse
is used to select suggestion.