### PR TITLE
hey look at this change and see if you want to merge it into master

### DIFF
--- a/js/bootstrap-suggest.js
+++ b/js/bootstrap-suggest.js
@@ -32,9 +32,9 @@
 		this.query = '';
 		this._queryPos = [];
 		this._keyPos = -1;
-
+            
 		this.$dropdown = $('<div />', {
-			'class': 'dropdown suggest',
+		    'class': 'dropdown suggest ' + this.options.dropdownClasses,
 			'html': $('<ul />', {'class': 'dropdown-menu', role: 'menu'}),
 			'data-key': this.key
 		});
@@ -452,13 +452,16 @@
 				el = $el.get(0);
 
 			if (!this.isShown) {
-				var caretPos = this.__getCaretPos(this._keyPos);
-				this.$dropdown
-					.addClass('open')
-					.find('.dropdown-menu').css({
-						'top': caretPos.top - el.scrollTop + 'px',
-						'left': caretPos.left - el.scrollLeft + 'px'
-					});
+				
+				this.$dropdown.addClass('open');
+				if (this.options.putDropdownBelowCaret) {
+				    var caretPos = this.__getCaretPos(this._keyPos);
+				    this.$dropdown.find('.dropdown-menu').css({
+				    	'top': caretPos.top - el.scrollTop + 'px',
+				    	'left': caretPos.left - el.scrollLeft + 'px'
+				    });
+				}
+					
 				this.isShown = true;
 				$el.trigger($.extend({type: 'suggest.show'}, this));
 			}
@@ -529,7 +532,8 @@
 			casesensitive: false,
 			limit: 5
 		},
-
+		dropdownClasses: '', //add another css class to the dropdown container. you can add 'dropup' to make the drop down to go bottom up (aka, dropup-menu), if you do it, make sure putDropdownBelowCaret: false
+		putDropdownBelowCaret: true, //true to maintain backwards compatibility
 		// events hook
 		onshow: function(e) {},
 		onselect: function(e, item) {},

--- a/js/bootstrap-suggest.js
+++ b/js/bootstrap-suggest.js
@@ -449,21 +449,47 @@
 
 		show: function() {
 			var $el = this.$element,
-				el = $el.get(0);
+				$dropdownMenu = this.$dropdown.find('.dropdown-menu'),
+				el = $el.get(0),
+				options = this.options,
+				caretPos,
+				position = {
+					top: 'auto',
+					bottom: 'auto',
+					left: 'auto',
+					right: 'auto'
+				};
 
 			if (!this.isShown) {
 				
 				this.$dropdown.addClass('open');
-				if (this.options.position !== false) {
-					var caretPos = this.__getCaretPos(this._keyPos);
-					if(this.options.position === 'default') {
-						this.$dropdown.find('.dropdown-menu').css({
-				    		'top': caretPos.top - el.scrollTop + 'px',
-				    		'left': caretPos.left - el.scrollLeft + 'px'
-				    	});
+				if (options.position !== false) {
+
+					caretPos = this.__getCaretPos(this._keyPos);
+
+					if (typeof options.position == 'string') {
+						switch (options.position) {
+							case 'bottom':
+								position.top = $el.outerHeight() - parseFloat($dropdownMenu.css('margin-top'));
+								position.left = 0;
+								position.right = 0;
+								break;
+							case 'top':
+								position.top = -($dropdownMenu.outerHeight(true) + parseFloat($dropdownMenu.css('margin-top')));
+								position.left = 0;
+								position.right = 0;
+								break;
+							case 'caret':
+								position.top = caretPos.top - el.scrollTop;
+								position.left = caretPos.left - el.scrollLeft;
+								break;
+						}
+
 					} else {
-						this.$dropdown.find('.dropdown-menu').css(this.options.position(el, caretPos));
+						position = typeof options.position == 'function' ? options.position(el, caretPos) : options.position;
 					}
+					
+					$dropdownMenu.css(position);
 				}
 				
 				this.isShown = true;
@@ -536,8 +562,8 @@
 			casesensitive: false,
 			limit: 5
 		},
-		dropdownClass: '', //add another css class to the dropdown container. you can add 'dropup' to make the drop down to go bottom up (aka, dropup-menu), if you do it, make sure putDropdownBelowCaret: position
-		position: 'default', //'default' / false / function(el, caretPos) { return { bottom: 'auto', left: 'auto', right: 'auto', top: 'auto'}; } //using caretPos, user can compute where the dropdown should go, should default to 'auto'
+		dropdownClass: '',
+		position: 'caret',
 		// events hook
 		onshow: function(e) {},
 		onselect: function(e, item) {},

--- a/js/bootstrap-suggest.js
+++ b/js/bootstrap-suggest.js
@@ -34,7 +34,7 @@
 		this._keyPos = -1;
             
 		this.$dropdown = $('<div />', {
-		    'class': 'dropdown suggest ' + this.options.dropdownClasses,
+		    'class': 'dropdown suggest ' + this.options.dropdownClass,
 			'html': $('<ul />', {'class': 'dropdown-menu', role: 'menu'}),
 			'data-key': this.key
 		});
@@ -454,14 +454,18 @@
 			if (!this.isShown) {
 				
 				this.$dropdown.addClass('open');
-				if (this.options.putDropdownBelowCaret) {
-				    var caretPos = this.__getCaretPos(this._keyPos);
-				    this.$dropdown.find('.dropdown-menu').css({
-				    	'top': caretPos.top - el.scrollTop + 'px',
-				    	'left': caretPos.left - el.scrollLeft + 'px'
-				    });
+				if (this.options.position !== false) {
+					var caretPos = this.__getCaretPos(this._keyPos);
+					if(this.options.position === 'default') {
+						this.$dropdown.find('.dropdown-menu').css({
+				    		'top': caretPos.top - el.scrollTop + 'px',
+				    		'left': caretPos.left - el.scrollLeft + 'px'
+				    	});
+					} else {
+						this.$dropdown.find('.dropdown-menu').css(this.options.position(el, caretPos));
+					}
 				}
-					
+				
 				this.isShown = true;
 				$el.trigger($.extend({type: 'suggest.show'}, this));
 			}
@@ -532,8 +536,8 @@
 			casesensitive: false,
 			limit: 5
 		},
-		dropdownClasses: '', //add another css class to the dropdown container. you can add 'dropup' to make the drop down to go bottom up (aka, dropup-menu), if you do it, make sure putDropdownBelowCaret: false
-		putDropdownBelowCaret: true, //true to maintain backwards compatibility
+		dropdownClass: '', //add another css class to the dropdown container. you can add 'dropup' to make the drop down to go bottom up (aka, dropup-menu), if you do it, make sure putDropdownBelowCaret: position
+		position: 'default', //'default' / false / function(el, caretPos) { return { bottom: 'auto', left: 'auto', right: 'auto', top: 'auto'}; } //using caretPos, user can compute where the dropdown should go, should default to 'auto'
 		// events hook
 		onshow: function(e) {},
 		onselect: function(e, item) {},

--- a/js/bootstrap-suggest.js
+++ b/js/bootstrap-suggest.js
@@ -486,7 +486,7 @@
 						}
 
 					} else {
-						position = typeof options.position == 'function' ? options.position(el, caretPos) : options.position;
+						position = $.extend(position, typeof options.position == 'function' ? options.position(el, caretPos) : options.position);
 					}
 					
 					$dropdownMenu.css(position);


### PR DESCRIPTION
this is not a bug, but a feature, this is why i didn't just push it to master
added two options to the plugin:
1. dropdownClasses - lets you add custom classes to $dropdown - can be used to add the bootstrap dropup class for dropup-menu
2. putDropdownBelowCaret - when the dropdown is shown - this lets you disable it's placement near the caret, needed when you want a dropup-menu