### PR TITLE
in IE9 selectionStart will always be 0 if not focused(when selecting …

### DIFF
--- a/js/bootstrap-suggest.js
+++ b/js/bootstrap-suggest.js
@@ -339,12 +339,11 @@
 			textInputRange,
 			len,
 			endRange;
+			el.focus();//in IE9 selectionStart will always be 9 if not focused(when selecting using the mouse)
 			if (typeof el.selectionStart == "number" && typeof el.selectionEnd == "number") {
 				start = el.selectionStart;
 				end = el.selectionEnd;
 			} else {
-				el.focus();
-				
 				range = document.selection.createRange();
 				
 				if (range && range.parentElement() === el) {


### PR DESCRIPTION
…using the mouse)
bug description:
on IE9 type @ -> 
you get the dropdown
select an option using the mouse
result - you get an extra @ before the entered text.
any text before the @ will also get in,
the solution is to focus before using el.selectionStart