### PR TITLE
Fix for #32: Event propagation

### DIFF
--- a/bootstrap-suggest.js
+++ b/bootstrap-suggest.js
@@ -210,7 +210,8 @@
 
 			$dropdown
 			.on('click', 'li:has(a)', function(e) {
-				e.preventDefault();
+                e.stopPropagation();
+                e.preventDefault();
 				that.__select($(this).index());
 				that.$element.focus();
 			})


### PR DESCRIPTION
Prevent click event from propagating and potentially selecting multiple items