### PR TITLE
Use `tab` key as `select` event trigger

### DIFF
--- a/src/bootstrap-suggest.js
+++ b/src/bootstrap-suggest.js
@@ -224,6 +224,7 @@
                 if (that.isShown) {
                     switch (e.keyCode) {
                         case 13: // enter key
+                        case 9: // tab key 
                             $visibleItems = that.__getVisibleItems();
                             $visibleItems.each(function(index) {
                                 if ($(this).is('.active'))


### PR DESCRIPTION
I suppose this should be default behavior.
Later, if there will be complaints about usage `tab` as an actual whitespace character (in the editable pre, for example), it could be added as an option.